### PR TITLE
fix: handle loop state on Fade direction up

### DIFF
--- a/packages/lib/src/Reveal.tsx
+++ b/packages/lib/src/Reveal.tsx
@@ -179,27 +179,28 @@ export const Reveal: React.FC<RevealProps> = (props) => {
                 onChange={onVisibilityChange}
               >
                 {({ inView, ref }) => (
-                  <div
-                    ref={ref}
-                    className={className}
-                    css={matchIfOrNull(() => animationStyles)(inView)}
-                    style={Object.assign({}, style, hideWhen(!inView), {
-                      animationDelay: nodeDelay + "ms",
-                    })}
-                  >
-                    <ClassNames>
-                      {({ cx }) => (
-                        <node.type
-                          {...node.props}
-                          className={cx(childClassName, node.props.className)}
-                          style={Object.assign(
-                            {},
-                            childStyle,
-                            node.props.style
-                          )}
-                        />
-                      )}
-                    </ClassNames>
+                  <div ref={ref}>
+                    <div
+                      className={className}
+                      css={matchIfOrNull(() => animationStyles)(inView)}
+                      style={Object.assign({}, style, hideWhen(!inView), {
+                        animationDelay: nodeDelay + "ms",
+                      })}
+                    >
+                      <ClassNames>
+                        {({ cx }) => (
+                          <node.type
+                            {...node.props}
+                            className={cx(childClassName, node.props.className)}
+                            style={Object.assign(
+                              {},
+                              childStyle,
+                              node.props.style
+                            )}
+                          />
+                        )}
+                      </ClassNames>
+                    </div>
                   </div>
                 )}
               </InView>


### PR DESCRIPTION
By using `<Fade direction="up">` without `triggerOnce`, the fade animation keeps being called until the user scrolls to the end of the child. This happens because the `InView` reference is assigned to an element that is transformed and translated down. As a result, when the animation is triggered, it enters into a loop.

To resolve this issue, we can add a `<div>` that wraps the transformed element and owns the reference.
This way, the animation will be triggered when the scroll reaches the top of the child, instead of the bottom.

**Related:** #68 #88 