### PR TITLE
fix: upgrade react-intersection-observer

### DIFF
--- a/.changeset/old-dodos-promise.md
+++ b/.changeset/old-dodos-promise.md
@@ -1,0 +1,5 @@
+---
+"react-awesome-reveal": patch
+---
+
+fix: upgrade react-intersection-observer

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -78,7 +78,7 @@
     "vite-plugin-dts": "3.6.2"
   },
   "dependencies": {
-    "react-intersection-observer": "^9.5.2",
+    "react-intersection-observer": "^9.5.3",
     "react-is": "^18.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
   packages/lib:
     dependencies:
       react-intersection-observer:
-        specifier: ^9.5.2
-        version: 9.5.2(react@18.2.0)
+        specifier: ^9.5.3
+        version: 9.5.3(react@18.2.0)
       react-is:
         specifier: ^18.2.0
         version: 18.2.0
@@ -5905,8 +5905,8 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-intersection-observer@9.5.2(react@18.2.0):
-    resolution: {integrity: sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==}
+  /react-intersection-observer@9.5.3(react@18.2.0):
+    resolution: {integrity: sha512-NJzagSdUPS5rPhaLsHXYeJbsvdpbJwL6yCHtMk91hc0ufQ2BnXis+0QQ9NBh6n9n+Q3OyjR6OQLShYbaNBkThQ==}
     peerDependencies:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:


### PR DESCRIPTION
Upgrade [react-interesction-observer](https://github.com/thebuilder/react-intersection-observer/pull/650) to fix issue with the `<InView>` component not rendering in Next.js.

Fixes #186 #187 and #191 